### PR TITLE
Add support for extra volumes and volumeMounts

### DIFF
--- a/charts/opensearch-operator/templates/opensearch-operator-controller-manager-deployment.yaml
+++ b/charts/opensearch-operator/templates/opensearch-operator-controller-manager-deployment.yaml
@@ -68,6 +68,8 @@ spec:
         {{- end }}
         securityContext:
 {{- toYaml .Values.manager.securityContext | nindent 10 }}
+        volumeMounts:
+{{- toYaml .Values.manager.extraVolumeMounts | nindent 10 }}
       nodeSelector:
 {{- toYaml .Values.nodeSelector | nindent 8 }}
       tolerations:
@@ -80,3 +82,5 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "opensearch-operator.serviceAccountName" . }}
       terminationGracePeriodSeconds: 10
+      volumes:
+{{- toYaml .Values.manager.extraVolumes | nindent 8 }}

--- a/charts/opensearch-operator/values.yaml
+++ b/charts/opensearch-operator/values.yaml
@@ -9,6 +9,8 @@ manager:
   securityContext:
     allowPrivilegeEscalation: false
   extraEnv: []
+  extraVolumes: []
+  extraVolumeMounts: []
   resources:
     limits:
       cpu: 200m


### PR DESCRIPTION
### Description
Add support to allow extra Volumes and VolumeMounts to be added to the opensearch-operator controller manager